### PR TITLE
[#240] fixes parseBoolean according spec

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -35,6 +35,12 @@
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/main/java/jakarta/xml/bind/DatatypeConverterImpl.java
+++ b/api/src/main/java/jakarta/xml/bind/DatatypeConverterImpl.java
@@ -289,7 +289,7 @@ final class DatatypeConverterImpl implements DatatypeConverterInterface {
                     ch = literal.charAt(i++);
                 } while ((strTrue.charAt(strIndex++) == ch) && i < len && strIndex < 3);
 
-                if (strIndex == 3) {
+                if (strIndex == 3 && strTrue.charAt(strIndex - 1) == ch) {
                     value = true;
                 } else {
                     throw new IllegalArgumentException("String \"" + literal + "\" is not valid boolean value.");
@@ -303,7 +303,7 @@ final class DatatypeConverterImpl implements DatatypeConverterInterface {
                 } while ((strFalse.charAt(strIndex++) == ch) && i < len && strIndex < 4);
 
 
-                if (strIndex == 4) {
+                if (strIndex == 4 && strFalse.charAt(strIndex - 1) == ch) {
                     value = false;
                 } else {
                     throw new IllegalArgumentException("String \"" + literal + "\" is not valid boolean value.");
@@ -312,10 +312,8 @@ final class DatatypeConverterImpl implements DatatypeConverterInterface {
                 break;
         }
 
-        if (i < len) {
-            do {
-                ch = literal.charAt(i++);
-            } while (WhiteSpaceProcessor.isWhiteSpace(ch) && i < len);
+        while (i < len && WhiteSpaceProcessor.isWhiteSpace(literal.charAt(i))) {
+            i++;
         }
 
         if (i == len) {

--- a/api/src/test/java/org/eclipse/jaxb/api/DatatypeConverterTest.java
+++ b/api/src/test/java/org/eclipse/jaxb/api/DatatypeConverterTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Distribution License v. 1.0, which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+package org.eclipse.jaxb.api;
+
+import jakarta.xml.bind.DatatypeConverter;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DatatypeConverterTest {
+
+    @Test
+    public void testParseBoolean() {
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean(null));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean(""));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("11"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("1A"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("non"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("fals"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("falses"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("false s"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("falst"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("tru"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("trux"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("truu"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("truxx"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("truth"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("truelle"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("truec"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("true c"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBoolean("oui"));
+
+
+        Assert.assertEquals(false, DatatypeConverter.parseBoolean("0"));
+        Assert.assertEquals(false, DatatypeConverter.parseBoolean(" 0"));
+        Assert.assertEquals(false, DatatypeConverter.parseBoolean(" 0 "));
+        Assert.assertEquals(false, DatatypeConverter.parseBoolean("0 "));
+        Assert.assertEquals(true, DatatypeConverter.parseBoolean("1"));
+        Assert.assertEquals(true, DatatypeConverter.parseBoolean(" 1"));
+        Assert.assertEquals(true, DatatypeConverter.parseBoolean(" 1 "));
+        Assert.assertEquals(true, DatatypeConverter.parseBoolean("1 "));
+        Assert.assertEquals(false, DatatypeConverter.parseBoolean("false"));
+        Assert.assertEquals(false, DatatypeConverter.parseBoolean(" false"));
+        Assert.assertEquals(false, DatatypeConverter.parseBoolean("false "));
+        Assert.assertEquals(false, DatatypeConverter.parseBoolean(" false "));
+        Assert.assertEquals(true, DatatypeConverter.parseBoolean("true"));
+        Assert.assertEquals(true, DatatypeConverter.parseBoolean(" true"));
+        Assert.assertEquals(true, DatatypeConverter.parseBoolean("true "));
+        Assert.assertEquals(true, DatatypeConverter.parseBoolean(" true "));
+    }
+}


### PR DESCRIPTION
Fixes #240 : `parseBoolean` function could return `true` or `false` value when, according to spec, it should not accept the string literal as valid boolean expression

Adding UT to validate behaviour