### PR TITLE
Handle empty string input for parseBase64Binary instead of throwing IllegalArgumentException

### DIFF
--- a/api/src/main/java/jakarta/xml/bind/DatatypeConverterImpl.java
+++ b/api/src/main/java/jakarta/xml/bind/DatatypeConverterImpl.java
@@ -711,13 +711,10 @@ final class DatatypeConverterImpl implements DatatypeConverterInterface {
      *      because JIT can inline a lot of string access (with data of 1K chars, it was twice as fast)
      */
     public static byte[] _parseBase64Binary(String text) {
-        if(text.isEmpty()) {
-            return new byte[0];
-        }
-        final int buflen = guessLength(text);
-        if (buflen < 3) {
+        if (null == text || text.length() % 4 != 0) {
             throw new IllegalArgumentException("base64 text invalid.");
         }
+        final int buflen = guessLength(text);
         final byte[] out = new byte[buflen];
         int o = 0;
 

--- a/api/src/main/java/jakarta/xml/bind/DatatypeConverterImpl.java
+++ b/api/src/main/java/jakarta/xml/bind/DatatypeConverterImpl.java
@@ -711,6 +711,9 @@ final class DatatypeConverterImpl implements DatatypeConverterInterface {
      *      because JIT can inline a lot of string access (with data of 1K chars, it was twice as fast)
      */
     public static byte[] _parseBase64Binary(String text) {
+        if(text.isEmpty()) {
+            return new byte[0];
+        }
         final int buflen = guessLength(text);
         if (buflen < 3) {
             throw new IllegalArgumentException("base64 text invalid.");

--- a/api/src/test/java/org/eclipse/jaxb/api/DatatypeConverterTest.java
+++ b/api/src/test/java/org/eclipse/jaxb/api/DatatypeConverterTest.java
@@ -84,6 +84,9 @@ public class DatatypeConverterTest {
     @Test
     public void testBase64() {
         Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBase64Binary("Qxx=="));
+
+        Assert.assertEquals("", new String(DatatypeConverter.parseBase64Binary("")));
+
         Assert.assertNotEquals("Hello, world!", new String(DatatypeConverter.parseBase64Binary("SGVsbG8sIJdvcmxkIQ==")));
 
         Assert.assertEquals("Hello, world!", new String(DatatypeConverter.parseBase64Binary("SGVsbG8sIHdvcmxkIQ==")));

--- a/api/src/test/java/org/eclipse/jaxb/api/DatatypeConverterTest.java
+++ b/api/src/test/java/org/eclipse/jaxb/api/DatatypeConverterTest.java
@@ -86,6 +86,12 @@ public class DatatypeConverterTest {
         Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBase64Binary("Qxx=="));
 
         Assert.assertEquals("", new String(DatatypeConverter.parseBase64Binary("")));
+        Assert.assertEquals("f", new String(DatatypeConverter.parseBase64Binary("Zg==")));
+        Assert.assertEquals("fo", new String(DatatypeConverter.parseBase64Binary("Zm8=")));
+        Assert.assertEquals("foo", new String(DatatypeConverter.parseBase64Binary("Zm9v")));
+        Assert.assertEquals("foob", new String(DatatypeConverter.parseBase64Binary("Zm9vYg==")));
+        Assert.assertEquals("fooba", new String(DatatypeConverter.parseBase64Binary("Zm9vYmE=")));
+        Assert.assertEquals("foobar", new String(DatatypeConverter.parseBase64Binary("Zm9vYmFy")));
 
         Assert.assertNotEquals("Hello, world!", new String(DatatypeConverter.parseBase64Binary("SGVsbG8sIJdvcmxkIQ==")));
 


### PR DESCRIPTION
Hi, after #282, parseBase64Binary throws IllegalArgumentException when called with an empty string

Reading through https://www.w3.org/TR/xmlschema-2 it seems like this is valid input
There is even a test vector `BASE64("") = ""` in https://www.rfc-editor.org/rfc/rfc4648#section-10
https://github.com/jakartaee/jaxb-api/pull/282/files#diff-2eef69682cb2debd3c0bb837aceb2da7d800a9145e133c709f9e9fb6ef0c3391L707-L710

Let me know if you would like me to create another PR adding some more test coverage
