### PR TITLE
[#325] restore permissive base64 decoding

### DIFF
--- a/api/src/main/java/jakarta/xml/bind/DatatypeConverterImpl.java
+++ b/api/src/main/java/jakarta/xml/bind/DatatypeConverterImpl.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -711,8 +712,8 @@ final class DatatypeConverterImpl implements DatatypeConverterInterface {
      *      because JIT can inline a lot of string access (with data of 1K chars, it was twice as fast)
      */
     public static byte[] _parseBase64Binary(String text) {
-        if (null == text || text.length() % 4 != 0) {
-            throw new IllegalArgumentException("base64 text invalid.");
+        if (null == text) {
+            throw new IllegalArgumentException("base64 \"null\" text invalid.");
         }
         final int buflen = guessLength(text);
         final byte[] out = new byte[buflen];
@@ -738,9 +739,15 @@ final class DatatypeConverterImpl implements DatatypeConverterInterface {
                 // quadruplet is now filled.
                 out[o++] = (byte) ((quadruplet[0] << 2) | (quadruplet[1] >> 4));
                 if (quadruplet[2] != PADDING) {
+                    if (buflen == o) {
+                        throw new IllegalArgumentException("base64 text invalid.");
+                    }
                     out[o++] = (byte) ((quadruplet[1] << 4) | (quadruplet[2] >> 2));
                 }
                 if (quadruplet[3] != PADDING) {
+                    if (buflen == o) {
+                        throw new IllegalArgumentException("base64 text invalid.");
+                    }
                     out[o++] = (byte) ((quadruplet[2] << 6) | (quadruplet[3]));
                 }
                 q = 0;

--- a/api/src/test/java/org/eclipse/jaxb/api/DatatypeConverterTest.java
+++ b/api/src/test/java/org/eclipse/jaxb/api/DatatypeConverterTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Distribution License v. 1.0, which is available at
@@ -84,6 +85,8 @@ public class DatatypeConverterTest {
     @Test
     public void testBase64() {
         Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBase64Binary("Qxx=="));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBase64Binary("SGVsbG8sIJdvcmxkIQQxx=="));
+        Assert.assertThrows(IllegalArgumentException.class, () -> DatatypeConverter.parseBase64Binary("dGhpcyBpcyB\nhbiBleGFtcGxl=="));
 
         Assert.assertEquals("", new String(DatatypeConverter.parseBase64Binary("")));
         Assert.assertEquals("f", new String(DatatypeConverter.parseBase64Binary("Zg==")));
@@ -92,6 +95,9 @@ public class DatatypeConverterTest {
         Assert.assertEquals("foob", new String(DatatypeConverter.parseBase64Binary("Zm9vYg==")));
         Assert.assertEquals("fooba", new String(DatatypeConverter.parseBase64Binary("Zm9vYmE=")));
         Assert.assertEquals("foobar", new String(DatatypeConverter.parseBase64Binary("Zm9vYmFy")));
+        Assert.assertEquals("this is an example", new String(DatatypeConverter.parseBase64Binary("dGhpcyBpcyB hbiBleGFtcGxl")));
+        Assert.assertEquals("this is an example", new String(DatatypeConverter.parseBase64Binary("dGhpcyBpcyB\nhbiBleGFtcGxl")));
+        Assert.assertEquals("this is an example", new String(DatatypeConverter.parseBase64Binary("dGhpcyBpcyB\thbiBleGFtcGxl")));
 
         Assert.assertNotEquals("Hello, world!", new String(DatatypeConverter.parseBase64Binary("SGVsbG8sIJdvcmxkIQ==")));
 


### PR DESCRIPTION
Fixes #325 

Regression from #309 and #282

If a character is not in base64 decoding map, it's ignored into the decoding process
newlines and spaces / tabulations or just ignored.

Restore previous base64 decoding function and protect code from throwing ArrayIndexOutOfBoundsException