### PR TITLE
[#366] add default attribute to XmlAttribute

### DIFF
--- a/api/src/main/java/jakarta/xml/bind/annotation/XmlAttribute.java
+++ b/api/src/main/java/jakarta/xml/bind/annotation/XmlAttribute.java
@@ -136,4 +136,15 @@ public @interface XmlAttribute {
      *
      */
     String namespace() default "##default";
+
+    /**
+     * Default value of this attribute.
+     *
+     * <p>
+     * The <pre>'\u0000'</pre> value specified as a default of this annotation element is used as a poor-man's
+     * substitute for null to allow implementations to recognize the 'no default value' state.
+     *
+     * @since 4.1
+     */
+    String defaultValue() default "\u0000";
 }


### PR DESCRIPTION
Fixes #366 

Proposal of adding `default` to `XmlAttribute` annotation like in `XmlElement`